### PR TITLE
Fix command injection vulnerability

### DIFF
--- a/lib/compass.js
+++ b/lib/compass.js
@@ -20,7 +20,7 @@ Compass.prototype.compile = function(options) {
   var compassOptions = merge(this.defaultOptions, options || {});
   var command = generateCommand(compassOptions);
   return new RSVP.Promise(function(resolve, reject) {
-    execFile(compassOptions.compassCommand, command, function(error, stdout, stderr) {
+    execFile('compass', command, function(error, stdout, stderr) {
       if (error) {
         if (stdout) { console.log(stdout); }
         if (stderr) { console.log(stderr); }

--- a/lib/compass.js
+++ b/lib/compass.js
@@ -1,13 +1,12 @@
-var exec  = require('child_process').exec;
+var execFile  = require('child_process').execFile;
 var merge = require('merge');
 var dargs = require('dargs');
 var RSVP  = require('rsvp');
 
 var generateCommand = function(options) {
-  var compassCommand = options.compassCommand;
   var excludes = ['compassCommand'];
   var args = dargs(options, { excludes: excludes });
-  var command = [compassCommand, 'compile'].concat(args).join(' ');
+  var command = ['compile'].concat(args);
   return command;
 };
 
@@ -20,9 +19,8 @@ function Compass() {
 Compass.prototype.compile = function(options) {
   var compassOptions = merge(this.defaultOptions, options || {});
   var command = generateCommand(compassOptions);
-
   return new RSVP.Promise(function(resolve, reject) {
-    exec(command, function(error, stdout, stderr) {
+    execFile(compassOptions.compassCommand, command, function(error, stdout, stderr) {
       if (error) {
         if (stdout) { console.log(stdout); }
         if (stderr) { console.log(stderr); }


### PR DESCRIPTION
### ⚙️ Abstract

`compass-compile` in its current state has a command injection vulnerability, and this PR focuses on fixing it. 

### ❓ Technical description

Instead of using `exec` and passing in the whole command as a string, I replaced it with execSync and passed in the arguments as an array, which gets properly sanitized by the child_process module built into Node.js. I've also removed the compassCommand config variable as someone could use it to execute any binary on the system.

### 🐛 Proof of Vulnerability (PoV)

Here is the original POC that would create a file named `JHU` when ran:
```js
var Root = require('compass-compile'); 
var root = new Root(); 
var options = { 
    compassCommand:"touch JHU"
     } 
root.compile(options);
```

### 🔥 Proof of Fix (PoF)

When the above POC is ran on my fork of this project, the `compass` command runs successfully instead of running `touch JHU`.